### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The test code requires Quick and Nimble to be implemented. You can do so by runn
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 DateInRegion is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
@@ -216,7 +216,7 @@ I have taken the following decisions when setting up the library. I welcome  fee
 Decision | Rationale
 ------------- | -------------
 Primary function of `DateInRegion` is to be able to switch and convert dates between regions. Not to deal with dates in the local region, although it can be used for that.|That is just the way I needed it :-)
-`DateInRegion` is not an extension to `NSDate` | `NSDate` extensions in general represent the current date in various formats. Extensions also limit the class as you cannot add stored properties. The latter I need to store the regional data (calendar, time zone & locale). Cocoapods offers plenty `NSDate` extensions e.g. [SwiftDate](www.cocoapods.com/pods/SwiftDate).
+`DateInRegion` is not an extension to `NSDate` | `NSDate` extensions in general represent the current date in various formats. Extensions also limit the class as you cannot add stored properties. The latter I need to store the regional data (calendar, time zone & locale). CocoaPods offers plenty `NSDate` extensions e.g. [SwiftDate](www.cocoapods.com/pods/SwiftDate).
 Do not include an initialiser from string  | That is too complicated with all the different ways of notation in the world. It would have too little benefit next to the currently available convenience intialisers instead.
 Do not attempt to mimic all properties and functions of the NSDateFormatter, NSDateComponents etc. E.g. NSDateFormatter's ``localizedStringFromDate`` or ``weekdaySymbols`` | Sometimes it is just easier to use the ``date`` property from ``DateInRegion`` instead.
 Equation ``==`` is not for just the date value but for the whole object | Alike NSObject regulations; although objects do not have to be the same instance, they must contain equal properties


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
